### PR TITLE
fix: keyfile position out of range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "one-time-pad"
-version = "0.2.0"
+version = "0.2.1"
 description = "A GUI application for easy use of one-time pad encryption written in Python."
 readme = "README.md"
 authors = [

--- a/src/one_time_pad/main_window.py
+++ b/src/one_time_pad/main_window.py
@@ -49,7 +49,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if message == "":
             Dialog("info", "Message empty", "Message input field empty. Nothing to encrypt.")
             return
-        ciphertext = otp.encode_data(self.encrypt_keyfile, message)
+        try:
+            ciphertext = otp.encode_data(self.encrypt_keyfile, message)
+        except OverflowError:
+            Dialog("error", "Overflow Error", "The remaining keyfile data is out of range.")
+            return
         if ciphertext is None:
             Dialog("error", "Key too short", "The selected key has not enough free bytes remaining. Try selecting a diffrent one")
             return

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ wheels = [
 
 [[package]]
 name = "one-time-pad"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
Handles an overflow exception that occurs when attempting to encrypt files where the new key position index is greater than the specified maximum uint32 value.