### PR TITLE
ci(renovate): update config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["dependencies", "devDependencies"],
+      "commitType": "build"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "commitType": "ci",
+      "pinDigests": true
+    }
   ]
 }


### PR DESCRIPTION
Dependencies use build commit type now and github-actions ci. Also forces to pin gh action workflows to commits.